### PR TITLE
php7 error: Parameter must be an array or an object that implements C…

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -26,7 +26,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
     /**
      * @var array
      */
-    protected $textColor = null;
+    protected $textColor = array();
 
     /**
      * @var array


### PR DESCRIPTION
…ountable in CaptchaBuilder.php on line 333

I got this error using xampp with php7 under windows 10 64bit.

Parameter must be an array or an object that implements Countable in CaptchaBuilder.php on line 333

I fixed it by declaring $textColor as array() at line 29.