### PR TITLE
Add option to ignore postEffects

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -100,6 +100,13 @@ class CaptchaBuilder implements CaptchaBuilderInterface
     protected $ignoreAllEffects = false;
 
     /**
+     * Ignore post effects
+     *
+     * @var bool
+     */
+    protected $ignorePostEffects = false;
+
+    /**
      * Allowed image types for the background images
      *
      * @var array
@@ -250,6 +257,19 @@ class CaptchaBuilder implements CaptchaBuilderInterface
     public function setIgnoreAllEffects($ignoreAllEffects)
     {
         $this->ignoreAllEffects = $ignoreAllEffects;
+
+        return $this;
+    }
+
+    /**
+     * Sets the ignorePostEffects value
+     *
+     * @param bool $ignorePostEffects
+     * @return CaptchaBuilder
+     */
+    public function setIgnorePostEffects($ignorePostEffects)
+    {
+        $this->ignorePostEffects = $ignorePostEffects;
 
         return $this;
     }
@@ -481,7 +501,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
         }
 
         // Post effects
-        if (!$this->ignoreAllEffects) {
+        if (!$this->ignoreAllEffects && !$this->ignorePostEffects) {
             $this->postEffect($image);
         }
 


### PR DESCRIPTION
Adds an option to only ignore postEffects (edge, negate, contrast, colorize) while keeping the other effects (behind/front lines, distortion) intact