### PR TITLE
explicitly cast to int

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -362,7 +362,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $w = $box[2] - $box[0];
             $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
             $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
-            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
+            \imagettftext($image, $size, $angle, $x, (int)$y + $offset, $col, $font, $symbol);
             $x += $w;
         }
 


### PR DESCRIPTION
there was error caused by implicit conversion from float to int in php 8.1
the easiest fix will be to explicitly cast the value to int as what it has been doing.
the issue is just, pre PHP 8.1 it will not complain when it's doing this, but since php 8.1 it will start throwing deprecation error.
