### PR TITLE
Exclude files from composer distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.github export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore
+/demo export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 /.gitattributes export-ignore
-/.github export-ignore
+/.github/ export-ignore
 /.gitignore export-ignore
-/.travis.yml export-ignore
 /phpunit.xml.dist export-ignore
-/tests export-ignore
-/demo export-ignore
+/tests/ export-ignore
+/demo/ export-ignore


### PR DESCRIPTION
It's common to exclude unnecessary files from the composer distribution - https://php.watch/articles/composer-gitattributes