### PR TITLE
The fourth parameter of imagettftext() in php8.1 adds float()

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -362,7 +362,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $w = $box[2] - $box[0];
             $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
             $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
-            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
+            \imagettftext($image, $size, $angle, floatval($x), $y + $offset, $col, $font, $symbol);
             $x += $w;
         }
 


### PR DESCRIPTION
error:Implicit conversion from float 35.5 to int loses precision