### PR TITLE
PHP-8 implicit conversion deprecation fix

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -345,8 +345,8 @@ class CaptchaBuilder implements CaptchaBuilderInterface
         $box = \imagettfbbox($size, 0, $font, $phrase);
         $textWidth = $box[2] - $box[0];
         $textHeight = $box[1] - $box[7];
-        $x = ($width - $textWidth) / 2;
-        $y = ($height - $textHeight) / 2 + $size;
+        $x = (int)(($width - $textWidth) / 2);
+        $y = (int)(($height - $textHeight) / 2 + $size);
 
         if (!$this->textColor) {
             $textColor = array($this->rand(0, 150), $this->rand(0, 150), $this->rand(0, 150));


### PR DESCRIPTION
Fix the error `Deprecated: Implicit conversion from float to int loses precision in /var/www/html/vendor/gregwar/captcha/src/Gregwar/Captcha/CaptchaBuilder.php on line 365`