### PR TITLE
Fix warning in PHP 8.2

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -362,8 +362,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $w = $box[2] - $box[0];
             $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
             $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
-            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
-            $x += $w;
+            \imagettftext($image, intval($size), intval($angle), intval($x), intval($y + $offset), $col, $font, $symbol);            $x += $w;
         }
 
         return $col;


### PR DESCRIPTION
On certain systems, when using PHP 8.2, the following warning will appear:
```
Deprecated: Implicit conversion from float 30.5 to int loses precision in (path)/vendor/gregwar/captcha/src/Gregwar/Captcha/CaptchaBuilder.php on line 365
```
When setting the header to `Content-type: image/jpeg`, the errors will not appear, but the image will be blank.
My proposed solution is to use `intval` to convert the floats to integers, thus solving this issue.
Thank you!