### PR TITLE
Update CaptchaBuilder.php

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -362,7 +362,10 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $w = $box[2] - $box[0];
             $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
             $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
-            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
+            
+            // fix for error Implicit conversion from float 37.5 to int loses precision
+            // add (int) $x, (int) $y
+            \imagettftext($image, $size, $angle, (int) $x, (int) $y + $offset, $col, $font, $symbol);
             $x += $w;
         }
 


### PR DESCRIPTION
// fix for error Implicit conversion from float 37.5 to int loses precision (tested on PHP 8.2)
// add (int) $x, (int) $y
\imagettftext($image, $size, $angle, (int) $x, (int) $y + $offset, $col, $font, $symbol);