### PR TITLE
Misc: Fix PHP 8 deprecation

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -362,7 +362,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $w = $box[2] - $box[0];
             $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
             $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
-            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
+            \imagettftext($image, $size, $angle, (int)$x, (int)($y + $offset), (int)$col, $font, $symbol);
             $x += $w;
         }
 


### PR DESCRIPTION
This fixes an “Implicit conversion from float to int loses precision” error in some cases.