### PR TITLE
Use cryptographically secure random generation for CAPTCHA phrases

### DIFF
--- a/src/Gregwar/Captcha/PhraseBuilder.php
+++ b/src/Gregwar/Captcha/PhraseBuilder.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gregwar\Captcha;
 
+use Gregwar\Captcha\Exception\InvalidArgumentException;
+
 /**
  * Generates random phrase
  *
@@ -65,6 +67,10 @@ class PhraseBuilder implements PhraseBuilderInterface
 
     private function getRandomCharacter(): string
     {
+        if ($this->charset === '') {
+            throw new InvalidArgumentException('Charset cannot be empty.');
+        }
+
         try {
             return $this->charset[random_int(0, strlen($this->charset) - 1)];
         } catch (\Random\RandomException $e) {

--- a/src/Gregwar/Captcha/PhraseBuilder.php
+++ b/src/Gregwar/Captcha/PhraseBuilder.php
@@ -34,7 +34,11 @@ class PhraseBuilder implements PhraseBuilderInterface
         $chars = str_split($this->charset);
 
         for ($i = 0; $i < $this->length; $i++) {
-            $phrase .= $chars[array_rand($chars)];
+            try {
+                $phrase .= $this->charset[random_int(0, strlen($this->charset) - 1)];
+            } catch (\Random\RandomException $e) {
+                $phrase .= $chars[array_rand($chars)];
+            }
         }
 
         return $phrase;

--- a/src/Gregwar/Captcha/PhraseBuilder.php
+++ b/src/Gregwar/Captcha/PhraseBuilder.php
@@ -31,14 +31,9 @@ class PhraseBuilder implements PhraseBuilderInterface
         }
 
         $phrase = '';
-        $chars = str_split($this->charset);
 
         for ($i = 0; $i < $this->length; $i++) {
-            try {
-                $phrase .= $this->charset[random_int(0, strlen($this->charset) - 1)];
-            } catch (\Random\RandomException $e) {
-                $phrase .= $chars[array_rand($chars)];
-            }
+            $phrase .= $this->getRandomCharacter();
         }
 
         return $phrase;
@@ -66,5 +61,16 @@ class PhraseBuilder implements PhraseBuilderInterface
     public static function comparePhrases(string $str1, string $str2): bool
     {
         return self::doNiceize($str1) === self::doNiceize($str2);
+    }
+
+    private function getRandomCharacter(): string
+    {
+        try {
+            return $this->charset[random_int(0, strlen($this->charset) - 1)];
+        } catch (\Random\RandomException $e) {
+            $chars = str_split($this->charset);
+
+            return $chars[array_rand($chars)];
+        }
     }
 }


### PR DESCRIPTION
Use random_int() to select characters from the configured charset.
Fall back to the original array_rand() implementation if secure random number generation is unavailable.
